### PR TITLE
July updates

### DIFF
--- a/experience.html
+++ b/experience.html
@@ -11,7 +11,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="Ariel Kennan | Civic Tech Executive | Bridging policy, technology, and design to improve government services.">
+    <meta name="description" content="Ariel Kennan | President, Axiom Foundation | Building open, machine-readable law, starting with tax and benefit policy.">
     <!-- Open Graph / social sharing -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Ariel Kennan">
@@ -95,7 +95,7 @@
        <div class="container">
         <hr>
 <h2>Bio</h2>
-       <p><h4>Ariel Kennan (she/her) is currently building a new open source technology nonprofit. Most recently, she was a Senior Director at the Beeck Center for Social Impact + Innovation at Georgetown University, where she researched and advised on advancing design, data, and technology for accessible and equitable delivery of public benefits. Ariel led the Digital Benefits Network to support practitioners in current and near term challenges in public benefits delivery and envisioning future policies, services, and technologies. She also served on the Beeck Center’s leadership team. </p>
+       <p><h4>Ariel Kennan (she/her) is the President of the <a href="https://axiom.org">Axiom Foundation</a>, a nonprofit publishing open, machine-readable encodings of the world’s rules — starting with tax and benefit policy — so anyone can run, audit, or reform them. Most recently, she was a Senior Director at the Beeck Center for Social Impact + Innovation at Georgetown University, where she researched and advised on advancing design, data, and technology for accessible and equitable delivery of public benefits. Ariel led the Digital Benefits Network to support practitioners in current and near term challenges in public benefits delivery and envisioning future policies, services, and technologies. She also served on the Beeck Center’s leadership team. </p>
 <p>Ariel is a transformative executive leader versed in organizational strategy, service design, digital product development, public policy, and network collaboration. With experience in the public, nonprofit, academic, and private sectors, she drives change and delivers impactful solutions. She is highly skilled at and has a passion for building initiatives from the ground up — including co-creating strategic vision and operational plans, fundraising, hiring and managing teams, and engaging diverse stakeholders. She is deeply committed to equity and justice and creating a world where everyone can prosper.
 </p>
  <p>Previously, she served in the New York City Mayor’s Office for Economic Opportunity where she founded the nation’s first municipal service design studio and managed a portfolio of best-in-class digital products to connect and deliver services. Most recently, she was the Director of Civic Innovation at Sidewalk Labs, where she led the strategy for inclusive participation in the social infrastructure of cities.</p>
@@ -103,6 +103,12 @@
 </h4><hr>
 <h2>Experience</h2>
 <h4>
+<p>
+ <p><a href="https://axiom.org"><strong>Axiom Foundation</strong></a> <br> New York, NY · July 2026 - Current
+<br><em>President</em>
+<body><ul>
+<li>Leading the Axiom Foundation's strategy, operations, partnerships, fundraising, and team-building.</li>
+</ul>
 <p>
  <p><a href="https://beeckcenter.georgetown.edu/"><strong>Beeck Center for Social Impact + Innovation at Georgetown University </strong></a> <br> New York, NY and Washington DC · February 2021 - June 2026
 <br><em>Senior Director (2024-2026), Senior Fellow & Research Faculty (2021-2024)</em>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="Ariel Kennan | Civic Tech Executive | Bridging policy, technology, and design to improve government services.">
+    <meta name="description" content="Ariel Kennan | President, Axiom Foundation | Building open, machine-readable law, starting with tax and benefit policy.">
     <!-- Open Graph / social sharing -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Ariel Kennan">
@@ -110,7 +110,7 @@
 <h5><p>I’m a transformative executive leader versed in organizational strategy, service design, digital product development, public policy, and network collaboration. I embed equity and justice in my work and strive to create a world where everyone can prosper. </h5></p>
 <Hr>
 <p><h4>
- I’m currently building a new open source technology nonprofit. Most recently, I was a Senior Director at the <a href="https://beeckcenter.georgetown.edu/"><strong> Beeck Center for Social Impact + Innovation</a></strong> at Georgetown University, where I researched and advised on advancing design, data, and technology for accessible and equitable delivery of public benefits. I led the<a href="https://beeckcenter.georgetown.edu/projects/digital-benefits-network/"> <strong>Digital Benefits Network</a></strong> to support practitioners in current and near term challenges in public benefits delivery and envisioning future policies, services, and technologies.</p>
+ I’m the President of the <a href="https://axiom.org"><strong>Axiom Foundation</strong></a>, a nonprofit publishing open, machine-readable encodings of the world’s rules — starting with tax and benefit policy — so anyone can run, audit, or reform them. Most recently, I was a Senior Director at the <a href="https://beeckcenter.georgetown.edu/"><strong> Beeck Center for Social Impact + Innovation</a></strong> at Georgetown University, where I researched and advised on advancing design, data, and technology for accessible and equitable delivery of public benefits. I led the<a href="https://beeckcenter.georgetown.edu/projects/digital-benefits-network/"> <strong>Digital Benefits Network</a></strong> to support practitioners in current and near term challenges in public benefits delivery and envisioning future policies, services, and technologies.</p>
  <p>I served the <a href="http://www.nyc.gov/opportunity"><strong>New York City Mayor’s Office for Economic Opportunity</a> </strong> as Director of Design and Product, where I founded the nation's first municipal <a href="https://civicservicedesign.com/about-the-service-design-studio-at-the-mayors-office-for-economic-opportunity-1f8d7c4fc423"><strong>service design studio</a></strong> and managed a <a href="https://www1.nyc.gov/site/opportunity/portfolio/products.page"><strong>portfolio of best-in-class digital products</a></strong> to connect and deliver services.</p>
  <p>
 As the Director of Civic Innovation at <a href="https://en.wikipedia.org/wiki/Sidewalk_Labs"><strong> Sidewalk Labs</a></strong>, I led the vision for civic life as part of the social infrastructure strategy to improve the quality of life in cities. </p>

--- a/press.html
+++ b/press.html
@@ -11,7 +11,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="Ariel Kennan | Civic Tech Executive | Bridging policy, technology, and design to improve government services.">
+    <meta name="description" content="Ariel Kennan | President, Axiom Foundation | Building open, machine-readable law, starting with tax and benefit policy.">
     <!-- Open Graph / social sharing -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Ariel Kennan">

--- a/projects.html
+++ b/projects.html
@@ -12,7 +12,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="Ariel Kennan | Civic Tech Executive | Bridging policy, technology, and design to improve government services.">
+    <meta name="description" content="Ariel Kennan | President, Axiom Foundation | Building open, machine-readable law, starting with tax and benefit policy.">
     <!-- Open Graph / social sharing -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Ariel Kennan">

--- a/speaking.html
+++ b/speaking.html
@@ -11,7 +11,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="Ariel Kennan | Civic Tech Executive | Bridging policy, technology, and design to improve government services.">
+    <meta name="description" content="Ariel Kennan | President, Axiom Foundation | Building open, machine-readable law, starting with tax and benefit policy.">
     <!-- Open Graph / social sharing -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Ariel Kennan">

--- a/writing.html
+++ b/writing.html
@@ -12,7 +12,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="Ariel Kennan | Civic Tech Executive | Bridging policy, technology, and design to improve government services.">
+    <meta name="description" content="Ariel Kennan | President, Axiom Foundation | Building open, machine-readable law, starting with tax and benefit policy.">
     <!-- Open Graph / social sharing -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Ariel Kennan">


### PR DESCRIPTION
Updates the site to reflect Ariel's new role as President of the **Axiom Foundation** ([axiom.org](https://axiom.org)).

## What changed
- **Homepage intro & bio** — now lead with "President of the Axiom Foundation" and a one-line mission (open, machine-readable encodings of the world's rules, starting with tax and benefit policy), replacing the placeholder "a new open source technology nonprofit" line. Links to axiom.org.
- **Experience** — added Axiom Foundation as the current entry at the top of the list: *President · New York, NY · July 2026 - Current*, with the bullet "Leading the Axiom Foundation's strategy, operations, partnerships, fundraising, and team-building."
- **Meta description** (all pages) — updated to "Ariel Kennan | President, Axiom Foundation | Building open, machine-readable law, starting with tax and benefit policy."

## Notes for reviewer
- Scope is intentionally light-touch. The Projects page still leads with the Digital Benefits Network, and the OG/Twitter social tags + `og-image.jpg` still say "Civic Tech Executive" — left for a follow-up.
- Beeck is already in past tense (from earlier PRs), so Axiom reads cleanly as the current role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)